### PR TITLE
Adds travis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ examples/*.nmf
 
 .rope*
 
+tags
+*.swp
+*.swo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install -r requirements.txt
+script:
+  nosetests -v
+notifications:
+  email:
+    recipients:
+      - ankursinha@fedoraproject.org
+    on_success: never
+    on_failure: always

--- a/readme.rst
+++ b/readme.rst
@@ -1,6 +1,9 @@
 btmorph v2
 ===========
 
+.. image:: https://travis-ci.org/sanjayankur31/btmorph_v2.svg?branch=master
+    :target: https://travis-ci.org/sanjayankur31/btmorph_v2
+
 Introduction
 ------------
 
@@ -18,12 +21,13 @@ You will need Python (2.7), `Numpy <http://numpy.org>`_ / `Scipy <http://scipy.o
 
 v2 is a new, object-oriented version of btmorph with a cleaner interface (API).
 
-v2 Also allows 3D plotting and animations using openGL. The following libraries are also required when using the plot3DGL function: `imageio <https://imageio.github.io/>`_ and `openGL <http://pyopengl.sourceforge.net/>`_. 
+v2 Also allows 3D plotting and animations using openGL. The following libraries are also required when using the plot3DGL function: `imageio <https://imageio.github.io/>`_ and `openGL <http://pyopengl.sourceforge.net/>`_.
 
 * Linux: Most linux distributions contain versions of these packages in their package manager that can readily be installed.
 
 * Windows and Mac: There are "scientific python" bundles that are shipped with all the aforementioned packages; most famously from `Anaconda <http://docs.continuum.io/anaconda/install.html>`_ or `Enthough <https://www.enthought.com/products/epd/free/>`_. Alternatively check the Ipython `installation <http://ipython.org/install.html>`_.
 
+* The required packages can be installed using `pip`: `pip install -r requirements.txt`. Use of a virtual environment is suggested when using `pip`.
 
 
 Proper installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy
+matplotlib
+h5py
+PyOpenGL
+imageio
+pillow
+scipy
+nose
+pycrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow
 scipy
 nose
 pycrypto
+ipython


### PR DESCRIPTION
This PR adds travis integration. At the moment, the current build status can be seen at my travis account here and it's linked to my fork of the repository only: https://travis-ci.org/sanjayankur31/btmorph_v2

To set this up on the main repo one will have to:

- merge the PR so that the travis.yml and other required files such as requirements.txt are available in the main repo
- modify the travis file to update the provided e-mail address for notifications (or remove it if not required)
- login to travis-ci.org using Github
- in "repositories", enable btmorph_v2 and modify any of the required settings
- update the travis build banner at the top of the readme.rst file to the new location

Any future pushes should automatically kick off travis builds. When pull requests are opened, if they can merge cleanly, travis will also test those out and update the pull request with the build status.